### PR TITLE
Document shared storage mounts

### DIFF
--- a/docs/absolute-beginner-guide.md
+++ b/docs/absolute-beginner-guide.md
@@ -101,11 +101,13 @@ Any workload requiring high-performance, extended runtime, or parallel execution
 
 REPACSS offers multiple storage environments optimized for different use cases:
 
-| Storage Type  | Location              | Environment Variable                            |
-|---------------|-----------------------|--------------------------------------------|
-| Home          | `/mnt/GROUPID/home/USERID`   | $HOME |
-| Scratch       | `/mnt/GROUPID/scratch/USERID`| $SCRATCH |
-| Work          | `/mnt/GROUPID/work/USERID`   | $WORK  |
+| Storage Type   | Location                       | Environment Variable |
+|----------------|--------------------------------|----------------------|
+| Home           | `/mnt/GROUPID/home/USERID`     | `$HOME`              |
+| Scratch        | `/mnt/GROUPID/scratch/USERID`  | `$SCRATCH`           |
+| Work           | `/mnt/GROUPID/work/USERID`     | `$WORK`              |
+| SHARED-AREA    | `/mnt/SHARED-AREA`             | Not applicable       |
+| SHARED-SCRATCH | `/mnt/SHARED-SCRATCH`          | Not applicable       |
 
 ### Checking Quotas
 REPACSS storage space usage is organized by your assigned group.
@@ -293,4 +295,3 @@ With these steps, new users are now equipped with the foundational knowledge to:
 - Submit and monitor jobs on the cluster
 
 Users are encouraged to explore the extended documentation to deepen their understanding and optimize their use of REPACSS resources. -->
-

--- a/docs/understanding/repacss-system/file-system/file-transfer.md
+++ b/docs/understanding/repacss-system/file-system/file-transfer.md
@@ -39,6 +39,8 @@ Follow these steps to enable file transfers using Globus Connect Personal:
      * Home: `/mnt/GROUPID/home/USERID`
      * Scratch: `/mnt/GROUPID/scratch/USERID`
      * Work: `/mnt/GROUPID/work/USERID`
+     * SHARED-AREA: `/mnt/SHARED-AREA`
+     * SHARED-SCRATCH: `/mnt/SHARED-SCRATCH`
 
 ---
 
@@ -64,4 +66,3 @@ Many academic and research institutions have established Globus endpoints. To tr
 * Monitor job completion using the Globus web interface.
 
 ---
-


### PR DESCRIPTION
Summary: Add SHARED-AREA and SHARED-SCRATCH to the beginner guide storage table and the Globus file-transfer storage path list. Validation: mkdocs build passes; the existing unrelated account/index.md link warning remains.